### PR TITLE
Virtual ESXi hosts can run 64bit OSes now

### DIFF
--- a/tests/test_vmware.py
+++ b/tests/test_vmware.py
@@ -147,6 +147,17 @@ class TestVMware(unittest.TestCase):
 
         self.assertEqual(output, expected)
 
+    @patch.object(vmware, 'consume_task')
+    def test_config_vm(self, fake_consume_task):
+        """``config_vm`` Enables hardware-assisted virtualization"""
+        fake_vm = MagicMock()
+        vmware.config_vm(fake_vm)
+
+        the_args, _ = fake_vm.ReconfigVM_Task.call_args
+        the_spec = the_args[0]
+
+        self.assertTrue(the_spec.nestedHVEnabled)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Turns out, you have to enable a guest VM access to hardware-based virtualization 😅 

https://communities.vmware.com/docs/DOC-8970

